### PR TITLE
feat: band-aid Eternal rating class support

### DIFF
--- a/Beans/DifficultyInfo.cs
+++ b/Beans/DifficultyInfo.cs
@@ -12,6 +12,8 @@ internal class DifficultyInfo
 
     static DifficultyInfo()
     {
+        List.TryAdd(4, new() { LongStr = "Eternal", ShortStr = "ETR", Alias = new[] { "etr", "eternal" }, Color = Color.FromArgb(93, 78, 118) });
+
         List.TryAdd(3, new() { LongStr = "Beyond", ShortStr = "BYD", Alias = new[] { "byn", "byd", "beyond" }, Color = Color.FromArgb(165, 20, 49) });
 
         List.TryAdd(2, new() { LongStr = "Future", ShortStr = "FTR", Alias = new[] { "ftr", "future" }, Color = Color.FromArgb(115, 35, 100) });

--- a/Beans/RecordInfo.cs
+++ b/Beans/RecordInfo.cs
@@ -12,7 +12,13 @@ internal class RecordInfo
     public RecordInfo(ArcSongdata recentdata)
     {
         Difficulty = recentdata.Difficulty;
-        SongInfo = ArcaeaCharts.QueryByID(recentdata.SongID)![Difficulty];
+        //limiting json document index as band-aid - JustVldKsh
+	if (Difficulty > 3) {Index = 3;} else {Index = Difficulty;};
+        SongInfo = ArcaeaCharts.QueryByID(recentdata.SongID)![Index];
+        //and setting RatingClass to 4 if Difficulty == 4 (ETR)
+        if (Difficulty == 4) {
+	    SongInfo.RatingClass = 4;
+        };
         Cleartype = recentdata.ClearType;
         SongID = recentdata.SongID;
         Rating = recentdata.Rating.ToString("0.0000");

--- a/Beans/RecordInfo.cs
+++ b/Beans/RecordInfo.cs
@@ -13,12 +13,10 @@ internal class RecordInfo
     {
         Difficulty = recentdata.Difficulty;
         //limiting json document index as band-aid - JustVldKsh
-	if (Difficulty > 3) {Index = 3;} else {Index = Difficulty;};
+        var Index = Difficulty > 3 ? 3 : Difficulty;
         SongInfo = ArcaeaCharts.QueryByID(recentdata.SongID)![Index];
         //and setting RatingClass to 4 if Difficulty == 4 (ETR)
-        if (Difficulty == 4) {
-	    SongInfo.RatingClass = 4;
-        };
+        if (Difficulty == 4) { SongInfo.RatingClass = 4; };
         Cleartype = recentdata.ClearType;
         SongID = recentdata.SongID;
         Rating = recentdata.Rating.ToString("0.0000");


### PR DESCRIPTION
Adds support for Eternal difficulty that was added back in March of this year without requiring to modify arcsong.json structure in any way

Should be good enough for the time being, since the game currently doesn't have both BYD and ETR charts on any song at the same time

- Closes ArcaeaOffline/client-pyside6#13